### PR TITLE
accept non-compliant json

### DIFF
--- a/src/main/kotlin/tech/simter/kotlin/serialization/JsonUtils.kt
+++ b/src/main/kotlin/tech/simter/kotlin/serialization/JsonUtils.kt
@@ -21,7 +21,8 @@ object JsonUtils {
   val cfg = JsonConfiguration.Stable.copy(
     ignoreUnknownKeys = true,
     encodeDefaults = false,
-    prettyPrint = false
+    prettyPrint = false,
+    isLenient = true
   )
 
   /** A kotlin json instance with [cfg] configuration to not encode defaults and ignore unknown keys */


### PR DESCRIPTION
use `jsonconfiguration.islenient = true` to accept non-compliant json